### PR TITLE
Relative test file path support added.

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,11 @@
                     "default": "{test,tests,Test,Tests}/**/*Test.php",
                     "scope": "resource"
                 },
+                "phpunit.relativeFilePath": {
+                    "description": "File path as relative argument instead of full path.",
+                    "type": "boolean",
+                    "default": false
+                },
                 "phpunit.clearOutputOnRun": {
                     "type": "boolean",
                     "default": true,

--- a/server/src/Configuration.ts
+++ b/server/src/Configuration.ts
@@ -6,6 +6,7 @@ import {
 interface IConfiguration {
     maxNumberOfProblems: number;
     files: string;
+    relativeFilePath: boolean;
     php?: string;
     phpunit?: string;
     args?: string[];
@@ -15,6 +16,7 @@ export class Configuration implements IConfiguration {
     defaults: IConfiguration = {
         maxNumberOfProblems: 10000,
         files: '**/*.php',
+        relativeFilePath: false
     };
 
     constructor(
@@ -28,6 +30,10 @@ export class Configuration implements IConfiguration {
 
     get files(): string {
         return this.defaults.files;
+    }
+
+    get relativeFilePath(): boolean {
+        return this.defaults.relativeFilePath;
     }
 
     get php(): string | undefined {

--- a/server/src/TestRunner.ts
+++ b/server/src/TestRunner.ts
@@ -17,6 +17,7 @@ export class TestRunner {
     private args: string[] = [];
     private lastArgs: string[] = [];
     private lastOutput: string = '';
+    private relativeFilePath: boolean = false;
     private lastCommand: Command = {
         title: '',
         command: '',
@@ -41,6 +42,12 @@ export class TestRunner {
 
     setArgs(args: string[] | undefined) {
         this.args = args || [];
+
+        return this;
+    }
+
+    setRelativeFilePath(relativeFilePath: boolean) {
+        this.relativeFilePath = relativeFilePath;
 
         return this;
     }
@@ -75,7 +82,11 @@ export class TestRunner {
         }
 
         if (p.file) {
-            params.push(this._files.asUri(p.file).fsPath);
+            let testFilePath = this._files.asUri(p.file).fsPath;
+            if (this.relativeFilePath && options && options.cwd) {
+                testFilePath = testFilePath.replace(new RegExp(options.cwd.replace(/\\/g, '\\\\') + '[\\/\\\\]'), '');
+            }
+            params.push(testFilePath);
         }
 
         return await this.doRun(params, options);

--- a/server/src/WorkspaceFolder.ts
+++ b/server/src/WorkspaceFolder.ts
@@ -129,7 +129,8 @@ export class WorkspaceFolder {
         this.testRunner
             .setPhpBinary(this.config.php)
             .setPhpUnitBinary(this.config.phpunit)
-            .setArgs(this.config.args);
+            .setArgs(this.config.args)
+            .setRelativeFilePath(this.config.relativeFilePath);
 
         const options = {
             cwd: this.fsPath(),


### PR DESCRIPTION
## How this option can help?
I want to be able to run unit tests on the Docker container.
This is my configuration file to do that.
```json
{
    "phpunit.phpunit": "C:/Program Files/Docker/Docker/resources/bin/docker.exe",
    "phpunit.args": ["exec", "-w", "Project path in container", "container id", "vendor/bin/phpunit", "-c", "phpunit.xml"]
}
```
This option helps to prevent error.
Result:
![screenshot](https://user-images.githubusercontent.com/16279288/78045735-8d825a00-738b-11ea-8888-8540289da1a7.gif)
