### PR TITLE
Support for Vagrant/Remote setups with small fixes and Troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Run your PHPUnit tests in Node using the
 * Install the extension
 * Restart VS Code and open the Test view
 * Run your tests using the ![Run](img/run.png) icons in the Test Explorer or the CodeLenses in your test file
+* For running phpunit on a remote system or using vagrant see Troubleshooting
 
 ## Configuration
 
@@ -45,3 +46,22 @@ ID                                 | Command
 `test-explorer.cancel`             | Cancel running tests
 
 ## Troubleshooting
+
+### All tests are appearing twice with "\*** duplicate ID **\*" found.
+You likely have a file sensitive file system. The default value of `"phpunit.files": "{test,tests,Test,Tests}/**/*Test.php",` should be changed to `"phpunit.files": "{test,tests}/**/*Test.php",`
+
+### I'm using Vagrant / Homestead for remote execution
+Your tests will list in the explorer for reading locally, but you need to run your tests remotely using PHP on your vagrant machine.
+
+To do this you need to configure the following settings:
+
+`"phpunit.relativeFilePath": true,` - This will ensure your files are located correctly for local checks
+
+`"phpunit.phpunit": "/FULL_PATH_TO/vendor/bin/phpunit",` - your remote path, likely in `/var/www/html/`
+
+`"phpunit.php": "/usr/local/bin/vagrant exec php",` this is to execute PHP on the remote machine. You'll need to install and configure https://github.com/p0deje/vagrant-exec - this wraps the command like using `ssh -C`
+
+You can also use the method above to execute on Docker remotely
+
+### My `/usr/local/bin/vagrant` isn't found?
+Spawn likely can't find vagrant locally. You need to switch to using your regular terminal using something like `"phpunit.shell": "/bin/bash",` or `"phpunit.shell": "/bin/zsh",`

--- a/package.json
+++ b/package.json
@@ -132,6 +132,21 @@
                     "default": "{test,tests,Test,Tests}/**/*Test.php",
                     "scope": "resource"
                 },
+                "phpunit.relativeFilePath": {
+                    "description": "File path as relative argument instead of full path.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "phpunit.remoteCwd": {
+                    "description": "Remote file path to the location of the root folder.",
+                    "type": "string",
+                    "default": ""
+                },
+                "phpunit.shell": {
+                    "description": "Shell to be used to call php.",
+                    "type": "string",
+                    "default": ""
+                },
                 "phpunit.clearOutputOnRun": {
                     "type": "boolean",
                     "default": true,

--- a/server/src/Configuration.ts
+++ b/server/src/Configuration.ts
@@ -4,8 +4,11 @@ import {
 } from 'vscode-languageserver';
 
 interface IConfiguration {
+    remoteCwd: string;
+    shell: string;
     maxNumberOfProblems: number;
     files: string;
+    relativeFilePath: boolean;
     php?: string;
     phpunit?: string;
     args?: string[];
@@ -15,6 +18,9 @@ export class Configuration implements IConfiguration {
     defaults: IConfiguration = {
         maxNumberOfProblems: 10000,
         files: '**/*.php',
+        relativeFilePath: false,
+        shell: '',
+        remoteCwd: '',
     };
 
     constructor(
@@ -28,6 +34,18 @@ export class Configuration implements IConfiguration {
 
     get files(): string {
         return this.defaults.files;
+    }
+
+    get relativeFilePath(): boolean {
+        return this.defaults.relativeFilePath;
+    }
+
+    get remoteCwd(): string {
+        return this.defaults.remoteCwd;
+    }
+
+    get shell(): string {
+        return this.defaults.shell;
     }
 
     get php(): string | undefined {

--- a/server/src/ProblemCollection.ts
+++ b/server/src/ProblemCollection.ts
@@ -7,8 +7,16 @@ import { TestNode, TestSuiteNode } from './TestNode';
 
 export class ProblemCollection {
     private problems: Map<string, ProblemNode> = new Map();
+    private remoteCwd: string = '';
 
     constructor(private _files = files) {}
+
+    setRemoteCwd(remoteCwd: string) {
+        this.remoteCwd = remoteCwd;
+        this._files.setRemoteCwd(this.remoteCwd);
+
+        return this;
+    }
 
     put(tests: TestEventGroup | TestEventGroup[]) {
         const problems = this.asProblems(

--- a/server/src/WorkspaceFolder.ts
+++ b/server/src/WorkspaceFolder.ts
@@ -129,10 +129,14 @@ export class WorkspaceFolder {
         this.testRunner
             .setPhpBinary(this.config.php)
             .setPhpUnitBinary(this.config.phpunit)
-            .setArgs(this.config.args);
+            .setArgs(this.config.args)
+            .setRelativeFilePath(this.config.relativeFilePath)
+
+        this.problems.setRemoteCwd(this.config.remoteCwd);
 
         const options = {
             cwd: this.fsPath(),
+            shell: this.config.shell,
         };
 
         rerun === false


### PR DESCRIPTION
Building on what @amir9480 had done for relative paths, I've taken this one step further to allow for remote execution of tests on systems like vagrant (or anything the relative path can be passed to)

I've also updated the troubleshooting guide to assist this, the issue with case insensitive file systems and made a small fix on matching tests.

## How this option can help?
Using Docker, vagrant or a remote host to run phpunit from test explorer can case "file not found" errors.

### Docker Example  
I want to be able to run unit tests on my Docker container. To do this, pass your docker executable and container parameters as your PHP executable

```
{
    "phpunit.relativeFilePath": true,
    "phpunit.php": "C:/Program Files/Docker/Docker/resources/bin/docker.exe exec -w PATH_TO_CONTAINER CONTAINER_ID php",
    "phpunit.phpunit": "vendor/bin/phpunit",
    "phpunit.args": ["-c", "phpunit.xml"]
}
```

### Vagrant / Homestead Example  
I want to be able to run unit tests on my Vagrant / Homestead machine. To do this, use vagrant exec (https://github.com/p0deje/vagrant-exec) as your PHP executable
```
{
    "phpunit.relativeFilePath": true,
    "phpunit.php": "/usr/local/bin/vagrant exec php",
    "phpunit.phpunit": "/FULL_PATH_TO_ROOT/vendor/bin/phpunit",
    "phpunit.args": ["-c", "phpunit.xml"],
    "phpunit.remoteCwd": "/FULL_PATH_TO_ROOT/",
}
```

### All tests are appearing twice with "\*** duplicate ID **\*" found.
You likely have a file sensitive file system. The default value of `"phpunit.files": "{test,tests,Test,Tests}/**/*Test.php",` should be changed to `"phpunit.files": "{test,tests}/**/*Test.php",`

### I'm using Vagrant / Homestead for remote execution
Your tests will list in the explorer for reading locally, but you need to run your tests remotely using PHP on your vagrant machine.

To do this you need to configure the following settings:

`"phpunit.relativeFilePath": true,` - This will ensure your files are located correctly for local checks

`"phpunit.phpunit": "/FULL_PATH_TO/vendor/bin/phpunit",` - your remote path, likely in `/var/www/html/`

`"phpunit.php": "/usr/local/bin/vagrant exec php",` this is to execute PHP on the remote machine. You'll need to install and configure https://github.com/p0deje/vagrant-exec - this wraps the command like using `ssh -C`

You can also use the method above to execute on Docker remotely

### My `/usr/local/bin/vagrant` isn't found?
Spawn likely can't find vagrant locally. You need to switch to using your regular terminal using something like `"phpunit.shell": "/bin/bash",` or `"phpunit.shell": "/bin/zsh",`