### PR TITLE
files in phpunit should not start with a dash or a space

### DIFF
--- a/server/src/OutputProblemMatcher.ts
+++ b/server/src/OutputProblemMatcher.ts
@@ -21,7 +21,7 @@ const statusPattern = new RegExp(
 );
 const classPattern = new RegExp('^\\d+\\)\\s(([^:]*)::([^\\s]*).*)$');
 const messagePattern = new RegExp('^(.*)$');
-const filesPattern = new RegExp('^(.*):(\\d+)$');
+const filesPattern = new RegExp('^[^ -](.*):(\\d+)$');
 
 export class OutputProblemMatcher extends ProblemMatcher {
     private currentStatus: Status = this.asStatus('failure');


### PR DESCRIPTION
when there is a php stacktrace in the output it like this:

```
Peak memory: 69.76 mo
Trace:
- /var/www/app/CommandApiTest.php:1230
- /var/www/app/Commands/Command.php:16
- /var/www/console:40

/var/www/proton/Foundation/Testing/ApiTestBase.php:102
/var/www/proton/Foundation/Testing/ApiTestBase.php:118
/var/www/app/Commands/Core/wrappers.php:16
```

the pattern was matching the whole lines of the stack trace including the `- ` at the start, and that makes the extension crash when trying to open files such as `- /var/www/app/CommandApiTest.php`

this PR prevents that by enforcing that the files path only begins with a character other than `-` or ` `. Maybe it should always starts with `/` because I don't think if PHP would output stack traces with relative paths but since I'm not sure stuck with `[^- ]`