### PR TITLE
URI Parsing error at Windows OS

### DIFF
--- a/server/src/Filesystem.ts
+++ b/server/src/Filesystem.ts
@@ -148,6 +148,10 @@ export class Filesystem {
         uri = uri as string;
 
         if (this.env.isWin()) {
+            if (uri.startsWith('phpvfscomposer://')) {
+                uri = uri.replace('phpvfscomposer://', '');
+            }
+
             uri = uri.replace(/\\/g, '/').replace(/^(\w):/i, m => {
                 return `/${m[0].toLowerCase()}%3A`;
             });


### PR DESCRIPTION
- fix #109 
- if phpunit output some files path with phpvfscomposer scheme(like this: `phpvfscomposer://C:\projects\php-project\vendor\phpunit\phpunit\phpunit:60`), then failed to parse URI object