### PR TITLE
disable boolean-negation

### DIFF
--- a/src/phpunit/command.test.ts
+++ b/src/phpunit/command.test.ts
@@ -69,6 +69,26 @@ describe('Command Test', () => {
                 '--colors=never',
             ]);
         });
+
+        it('should not transform arguments prefixed with --no to boolean', () => {
+            const cwd = projectPath('');
+            const configuration = new Configuration({
+                php: 'php',
+                phpunit: 'vendor/bin/phpunit',
+                args: ['--no-coverage', '--no-logging'],
+            });
+            const command = new LocalCommand(configuration, { cwd });
+
+            const { cmd, args } = command.apply();
+            expect(cmd).toEqual('php');
+            expect(args).toEqual([
+                'vendor/bin/phpunit',
+                '--no-coverage',
+                '--no-logging',
+                '--teamcity',
+                '--colors=never',
+            ]);
+        });
     });
 
     describe('RemoteCommand', () => {

--- a/src/phpunit/command.ts
+++ b/src/phpunit/command.ts
@@ -181,6 +181,7 @@ export abstract class Command {
             configuration: {
                 // eslint-disable-next-line @typescript-eslint/naming-convention
                 'camel-case-expansion': false,
+                'boolean-negation': false,
             },
         });
 


### PR DESCRIPTION
This pull request aims to address the issue displayed here https://github.com/recca0120/vscode-phpunit/issues/134.
Where CLI arguments prefixed with --no get transformed to boolean args.
E.g. "--no-coverage" gets transformed to "--coverage=false" which is not a valid [PHPUnit CLI option](https://phpunit.readthedocs.io/en/9.5/textui.html#command-line-options).