### PR TITLE
consider 'sail' being a remote command

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -61,7 +61,7 @@ export class Handler {
     private isRemote() {
         const command = (this.configuration.get('command') as string) ?? '';
 
-        return command.match(/docker|ssh/) !== null;
+        return command.match(/docker|ssh|sail/) !== null;
     }
 
     private createTestRunner(


### PR DESCRIPTION
Heyhey, the "phpunit.paths" settings seems only to be applied to test files when command is issued against remote targets (see also #150. I added `sail` to these, since it is Laravel's tool for interacting with docker containers and is very convinient to use in a laravel/docker environment.

