### PR TITLE
Support specifying a subdirectory for PHP files

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,21 @@ The following commands are available in VS Code's command palette, use the ID to
 }
 ```
 
+Use `phpSubdir` when your PHP files are in a subdirectory of your workspace folder:
+
+```jsonc
+{
+  "phpunit.php": "/usr/bin/php",
+  "phpunit.command": "docker exec -t my-container /bin/sh -c",
+  "phpunit.phpunit": "/var/www/html/vendor/bin/phpunit",
+  "phpunit.args": ["-c", "phpunit.xml"],
+  "phpunit.paths": {
+      "${workspaceFolder}/src": "/var/www/html",
+  },
+  "phpunit.phpSubdir": "src",
+}
+```
+
 ### SSH
 
 ```jsonc

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Use `phpSubdir` when your PHP files are in a subdirectory of your workspace fold
   "phpunit.php": "/usr/bin/php",
   "phpunit.command": "docker exec -t my-container /bin/sh -c",
   "phpunit.phpunit": "/var/www/html/vendor/bin/phpunit",
-  "phpunit.args": ["-c", "phpunit.xml"],
+  "phpunit.args": ["-c", "src/phpunit.xml"],
   "phpunit.paths": {
       "${workspaceFolder}/src": "/var/www/html",
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "PHPUnit Test Explorer",
   "icon": "img/icon.png",
   "publisher": "recca0120",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "private": true,
   "license": "MIT",
   "repository": {
@@ -116,6 +116,11 @@
           "default": "onFailure",
           "description": "Specify if the test report will automatically be shown after execution",
           "scope": "application"
+        },
+        "phpunit.phpSubdir": {
+          "type": "string",
+          "default": "",
+          "description": "If present will use this subdirectory (relative to the workspace folder) when looking for phpunit.xml and test files."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -140,8 +140,17 @@ async function getWorkspaceTestPatterns() {
         const includePatterns = [];
         const excludePatterns = ['**/.git/**', '**/node_modules/**'];
 
+        let phpDir = workspaceFolder.uri.fsPath;
+
+        const config = vscode.workspace.getConfiguration();
+        const phpSubdir = config.get('phpunit.phpSubdir') as string;
+
+        if (phpSubdir) {
+            phpDir += '/' + phpSubdir;
+        }
+
         const path = ['phpunit.xml', 'phpunit.dist.xml']
-            .map((path) => workspaceFolder.uri.fsPath + '/' + path)
+            .map((path) => phpDir + '/' + path)
             .find(async (path) => await checkFileExists(path));
 
         if (path) {
@@ -158,14 +167,14 @@ async function getWorkspaceTestPatterns() {
         }
 
         if (includePatterns.length === 0) {
-            includePatterns.push('tests/**/*.php');
-            excludePatterns.push('**/vendor/**');
+            includePatterns.push('${phpDir}/tests/**/*.php');
+            excludePatterns.push('${phpDir}/**/vendor/**');
         }
 
         results.push({
             workspaceFolder,
-            pattern: new vscode.RelativePattern(workspaceFolder, `{${includePatterns.join(',')}}`),
-            exclude: new vscode.RelativePattern(workspaceFolder, `{${excludePatterns.join(',')}}`),
+            pattern: new vscode.RelativePattern(vscode.Uri.file(phpDir), `{${includePatterns.join(',')}}`),
+            exclude: new vscode.RelativePattern(vscode.Uri.file(phpDir), `{${excludePatterns.join(',')}}`),
         });
     }
     return results;


### PR DESCRIPTION
## Description

Feature to address #180 

Allows the user to specify where in a workspace folder to look for `phpunit.xml` and PHP test files.

## Example

A workspace folder looks like this:
```
/assets
/docker
/src
    /tests
    index.php
    phpunit.xml
```

The developer can now provide config like the following to find the PHP files (note `phpunit.phpSubdir`):

```jsonc
{
  "phpunit.php": "/usr/bin/php",
  "phpunit.command": "docker exec -t my-container /bin/sh -c",
  "phpunit.phpunit": "/var/www/html/vendor/bin/phpunit",
  "phpunit.args": ["-c", "phpunit.xml"],
  "phpunit.paths": {
      "${workspaceFolder}/src": "/var/www/html",
  },
  "phpunit.phpSubdir": "src",
}
```