### PR TITLE
fix: Create new CommandBuilder object for each test

### DIFF
--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -54,9 +54,11 @@ export class Handler {
             const processes = !request.include
                 ? [runner.run(builder)]
                 : request.include
-                    .map((test) => this.testCollection.getTestCase(test)!)
-                    .map((testCase) => runner.run(testCase.update(builder)));
-
+                    .map((test) => {
+                        const testCase = this.testCollection.getTestCase(test)!
+                        const builder = new CommandBuilder(this.configuration, { cwd: this.testCollection.getWorkspace().fsPath });
+                        return runner.run(testCase.update(builder))
+                    });
             cancellation?.onCancellationRequested(() => processes.forEach((process) => process.abort()));
 
             await Promise.all(processes.map((process) => process.run()));


### PR DESCRIPTION
When I select more than one test and run them at the same time, even tho phpunit gets executed multiple times, it always runs only one test. This is because the same builder object was used and each test from the `request.include` list just modified the same object...

Note that the `outputChannel` suffers from similar issue. Each running test will clear the output (code in `OutputChannelObserver`) and so we will be left with only the output of the last test...

Ideally PHP unit should be run only once - but I do not know yet how to get it to run different tests in possible different suits...