### PR TITLE
feat: Add Debug run profile and integrate with xdebug.php-debug

### DIFF
--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -54,9 +54,11 @@ export class Handler {
             const processes = !request.include
                 ? [runner.run(builder)]
                 : request.include
-                    .map((test) => this.testCollection.getTestCase(test)!)
-                    .map((testCase) => runner.run(testCase.update(builder)));
-
+                    .map((test) => {
+                        const testCase = this.testCollection.getTestCase(test)!
+                        const builder = new CommandBuilder(this.configuration, { cwd: this.testCollection.getWorkspace().fsPath });
+                        return runner.run(testCase.update(builder))
+                    });
             cancellation?.onCancellationRequested(() => processes.forEach((process) => process.abort()));
 
             await Promise.all(processes.map((process) => process.run()));

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -5,7 +5,9 @@ import {
     TestItem,
     TestItemCollection,
     TestRunRequest,
+    TestRunProfileKind,
 } from 'vscode';
+import * as vscode from 'vscode';
 import { Configuration } from './Configuration';
 import { CollisionPrinter, OutputChannelObserver, TestResultObserver } from './Observers';
 import { CommandBuilder, TestRunner, TestType } from './PHPUnit';
@@ -21,7 +23,7 @@ export class Handler {
     }
 
     async startTestRun(request: TestRunRequest, cancellation?: CancellationToken) {
-        const builder = new CommandBuilder(this.configuration, { cwd: this.testCollection.getWorkspace().fsPath });
+        const builder = new CommandBuilder(this.configuration, { cwd: this.testCollection.getWorkspace().fsPath }, request.profile?.kind);
         const queue: { test: TestItem; data: TestCase }[] = [];
         const run = this.ctrl.createTestRun(request);
 
@@ -56,12 +58,22 @@ export class Handler {
                 : request.include
                     .map((test) => {
                         const testCase = this.testCollection.getTestCase(test)!
-                        const builder = new CommandBuilder(this.configuration, { cwd: this.testCollection.getWorkspace().fsPath });
+                        const builder = new CommandBuilder(this.configuration, { cwd: this.testCollection.getWorkspace().fsPath }, request.profile?.kind);
                         return runner.run(testCase.update(builder))
                     });
             cancellation?.onCancellationRequested(() => processes.forEach((process) => process.abort()));
 
+            if (request.profile?.kind == TestRunProfileKind.Debug) {
+                const wsf = vscode.workspace.getWorkspaceFolder(this.testCollection.getWorkspace());
+                await vscode.debug.startDebugging(wsf, { type: 'php', request: 'launch', name: 'PHPUnit' });
+                // TODO: perhaps wait for the debug session
+            }
+
             await Promise.all(processes.map((process) => process.run()));
+
+            if (request.profile?.kind == TestRunProfileKind.Debug && vscode.debug.activeDebugSession && vscode.debug.activeDebugSession.type === 'php') {
+                vscode.debug.stopDebugging(vscode.debug.activeDebugSession);
+            }
 
             return;
         };

--- a/src/PHPUnit/CommandBuilder/CommandBuilder.ts
+++ b/src/PHPUnit/CommandBuilder/CommandBuilder.ts
@@ -4,12 +4,13 @@ import { Configuration, IConfiguration } from '../Configuration';
 import { TestResult } from '../ProblemMatcher';
 import { parseValue } from '../utils';
 import { Path, PathReplacer } from './PathReplacer';
+import { TestRunProfileKind } from 'vscode';
 
 export class CommandBuilder {
     private arguments = '';
     private readonly pathReplacer: PathReplacer;
 
-    constructor(protected configuration: IConfiguration = new Configuration(), private options: SpawnOptions = {}) {
+    constructor(protected configuration: IConfiguration = new Configuration(), private options: SpawnOptions = {}, private kind: TestRunProfileKind = TestRunProfileKind.Run ) {
         this.pathReplacer = this.resolvePathReplacer(options, configuration);
     }
 
@@ -50,7 +51,8 @@ export class CommandBuilder {
 
     private createCommand() {
         const command = this.getCommand();
-        const executable = this.setParaTestFunctional([this.getPhp(), this.getPhpUnit(), ...this.getArguments()]);
+        const extra = this.kind == TestRunProfileKind.Debug ? ['-dxdebug.mode=debug', '-dxdebug.start_with_request=1'] : []
+        const executable = this.setParaTestFunctional([this.getPhp(), ...extra, this.getPhpUnit(), ...this.getArguments()]);
 
         if (!/^ssh/.test(command.join(' ')) && !/sh\s+-c/.test(command.slice(-2).join(' '))) {
             return [...command, ...executable];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import {
     workspace,
     WorkspaceFolder,
 } from 'vscode';
+import * as vscode from 'vscode';
 import { CommandHandler } from './CommandHandler';
 import { Configuration } from './Configuration';
 import { Handler } from './Handler';
@@ -105,6 +106,9 @@ export async function activate(context: ExtensionContext) {
         }
     };
     const testRunProfile = ctrl.createRunProfile('Run Tests', TestRunProfileKind.Run, runHandler, true, undefined, true);
+    if (vscode.extensions.getExtension('xdebug.php-debug') != undefined) {
+        const testDebugProfile = ctrl.createRunProfile('Debug Tests', TestRunProfileKind.Debug, runHandler, false, undefined, false);
+    }
     const commandHandler = new CommandHandler(testCollection, testRunProfile);
 
     context.subscriptions.push(commandHandler.reload(reload));


### PR DESCRIPTION
Proposal for integration with php-debug extension. I'm the developer of that extension.

A lot is assumed here. That Xdebug is installed in the current php and that the configuration has some sane defaults. Namely, that `xdebug.client_port` is the default 9003 and also `xdebug.client_host` does not conflict. Some of these could be forced via php cli options the same way that `xdebug.mode` and `xdebug.start_with_request` are.

I intend to add support for coverage.