### PR TITLE
fix: Do not call run.end() before all tests are done.

### DIFF
--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -68,12 +68,15 @@ export class Handler {
                 // TODO: perhaps wait for the debug session
             }
 
-            await Promise.all(processes.map((process) => process.run()));
+            while (processes.length > 0) {
+                await processes.shift()?.run();
+            }
 
             if (request.profile?.kind === TestRunProfileKind.Debug && debug.activeDebugSession && debug.activeDebugSession.type === 'php') {
                 debug.stopDebugging(vscode.debug.activeDebugSession);
             }
 
+            run.end();
             return;
         };
 

--- a/src/Observers/TestResultObserver.ts
+++ b/src/Observers/TestResultObserver.ts
@@ -37,7 +37,8 @@ export class TestResultObserver implements TestRunnerObserver {
     }
 
     close(): void {
-        this.testRun.end();
+        // Do not call testRun.end() as this would prevent other test runners from reporting test results.
+        // this.testRun.end();
     }
 
     testSuiteStarted(result: TestSuiteStarted): void {


### PR DESCRIPTION
Do not call `run.end()` from `TestResultObserver` because there could be more tests. Run phpunit instances sequentially.