### PR TITLE
Enhance test result parser

### DIFF
--- a/src/AppState.ts
+++ b/src/AppState.ts
@@ -1,0 +1,58 @@
+export class AppState {
+    private static instance: AppState;
+
+    public static getInstance(): AppState {
+        if (!AppState.instance) {
+            AppState.instance = new AppState();
+        }
+
+        return AppState.instance;
+    }
+
+    private static readonly MAX_ENTRIES = 1000;
+
+    /**
+     * Map parser unique id to whether it's a Pest test
+     */
+    public parserTestTypeMap: Map<string, boolean>;
+
+    private constructor() {
+        this.parserTestTypeMap = new Map<string, boolean>();
+    }
+
+    private static cleanup(): void {
+        const instance = AppState.getInstance();
+        const mapSize = instance.parserTestTypeMap.size;
+
+
+        if (mapSize < AppState.MAX_ENTRIES) {
+            return;
+        }
+
+        const entriesToDelete = mapSize - AppState.MAX_ENTRIES;
+        const iterator = instance.parserTestTypeMap.keys();
+        for (let i = 0; i < entriesToDelete; i++) {
+            const key = iterator.next().value;
+            key && instance.parserTestTypeMap.delete(key);
+        }
+    }
+
+    /**
+     * Set whether a parser is a Pest test
+     * @param parserId Unique identifier for the parser
+     * @param isPest Boolean indicating if it's a Pest test
+     */
+    public static setParserTestType(parserId: string, isPest: boolean): void {
+        AppState.getInstance().parserTestTypeMap.set(parserId, isPest);
+        AppState.cleanup();
+    }
+
+    /**
+     * Get whether a parser is a Pest test
+     * @param parserId Unique identifier for the parser
+     * @returns Boolean indicating if it's a Pest test, or undefined if not set
+     */
+    public static getParserTestType(parserId: string): boolean | undefined {
+        return AppState.getInstance().parserTestTypeMap.get(parserId);
+    }
+}

--- a/src/PHPUnit/ProblemMatcher/TestResultParser.ts
+++ b/src/PHPUnit/ProblemMatcher/TestResultParser.ts
@@ -79,7 +79,10 @@ export class TestResultParser implements IParser<TestResult | undefined> {
             return {};
         }
 
-        return TransformerFactory.factory(argv.locationHint).fromLocationHit(argv.locationHint, argv.name);
+        return TransformerFactory.factory({
+            locationHint: argv.locationHint,
+            testResultName: argv.name,
+        }).fromLocationHit(argv.locationHint, argv.name);
     }
 
     private toTeamcityArgv(text: string): Pick<Arguments, string | number> {

--- a/src/PHPUnit/TestParser/PHPUnitParser.ts
+++ b/src/PHPUnit/TestParser/PHPUnitParser.ts
@@ -3,6 +3,7 @@ import { Parser } from './Parser';
 import { TransformerFactory } from './Transformers';
 import { TestDefinition, TestType } from './types';
 import { validator } from './Validator';
+import { AppState } from '../../AppState';
 
 export class PHPUnitParser extends Parser {
     private parserLookup: { [p: string]: Function } = {
@@ -33,6 +34,7 @@ export class PHPUnitParser extends Parser {
         const className = this.parseName(declaration)!;
         const classFQN = [namespace?.namespace, className].filter((name) => !!name).join('\\');
         const id = this.converter.uniqueId({ type, classFQN, annotations });
+        AppState.setParserTestType(id, false);
         const label = this.converter.generateLabel({ type, classFQN, className, annotations });
 
         const clazz = {

--- a/src/PHPUnit/TestParser/PestParser.ts
+++ b/src/PHPUnit/TestParser/PestParser.ts
@@ -4,6 +4,7 @@ import { capitalize } from '../utils';
 import { Parser } from './Parser';
 import { TransformerFactory } from './Transformers';
 import { TestDefinition, TestType } from './types';
+import { AppState } from '../../AppState';
 
 export class PestParser extends Parser {
     private converter = TransformerFactory.factory('pest');
@@ -38,6 +39,7 @@ export class PestParser extends Parser {
         const className = partsFQN.pop()!;
         const namespace = partsFQN.join('\\');
         const id = this.converter.uniqueId({ type, classFQN });
+        AppState.setParserTestType(id, true);
         const label = this.converter.generateLabel({ type, classFQN, className });
 
         const { start, end } = this.parsePosition(declaration);

--- a/src/PHPUnit/TestParser/Transformers/TransformerFactory.test.ts
+++ b/src/PHPUnit/TestParser/Transformers/TransformerFactory.test.ts
@@ -1,0 +1,64 @@
+import { TransformerFactory } from './TransformerFactory';
+import { AppState } from '../../../AppState';
+
+/**
+ * Test suite for TransformerFactory
+ *
+ * This test suite addresses an issue where locationHint starting with 'file://'
+ * was incorrectly identified as non-Pest test files. This was observed with:
+ * - PHP 8.1.31
+ * - Pest 2.36.0
+ * - PHPUnit 10.5.36
+ *
+ * ##teamcity[testSuiteStarted name='Tests\Feature\ExampleTest' locationHint='file://tests/Feature/ExampleTest.php' flowId='OOOO']
+ */
+describe('TransformerFactory', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+        AppState.getInstance().parserTestTypeMap.clear();
+    });
+
+    const testCases = [
+        { input: 'pest', expected: true },
+        { input: 'P\\', expected: true },
+        { input: 'pest_qn://', expected: true },
+        { input: 'php_qn://', expected: false },
+        { input: 'file://test.php', expected: false },
+        { input: 'other', expected: false },
+    ];
+
+    testCases.forEach(({ input, expected }) => {
+        test(`isPest with input "${input}" should return ${expected}`, () => {
+            expect(TransformerFactory.isPest(input)).toBe(expected);
+        });
+    });
+
+    test('isPest with TransformerInput object (locationHint)', () => {
+        AppState.setParserTestType('Tests\\Feature\\ExampleTest', true);
+        expect(TransformerFactory.isPest({ locationHint: 'file://tests/Feature/FooTest.php', testResultName: 'Test Suite' })).toBe(false);
+        expect(TransformerFactory.isPest({ locationHint: 'file://tests/Feature/FooTest.php', testResultName: 'path/to/phpunit.xml' })).toBe(false);
+        expect(TransformerFactory.isPest({ locationHint: 'file://tests/Feature/ExampleTest.php', testResultName: 'Test Suite' })).toBe(true);
+        expect(TransformerFactory.isPest({ locationHint: 'file://tests/Feature/ExampleTest.php', testResultName: 'path/to/phpunit.xml' })).toBe(true);
+    });
+
+    test('isPest with TransformerInput object (classFQN)', () => {
+        expect(TransformerFactory.isPest({ classFQN: 'pest' })).toBe(true);
+        expect(TransformerFactory.isPest({ classFQN: 'other' })).toBe(false);
+    });
+
+    test('factory method returns correct transformer', () => {
+        const pestTransformer = TransformerFactory.factory('pest');
+        const phpunitTransformer = TransformerFactory.factory('php_qn://');
+
+        expect(pestTransformer.constructor.name).toBe('PestTransformer');
+        expect(phpunitTransformer.constructor.name).toBe('PHPUnitTransformer');
+    });
+
+    test('factory method with TransformerInput object', () => {
+        const pestTransformer = TransformerFactory.factory({ locationHint: 'pest_qn://', testResultName: 'TestName' });
+        const phpunitTransformer = TransformerFactory.factory({ locationHint: 'php_qn://' });
+
+        expect(pestTransformer.constructor.name).toBe('PestTransformer');
+        expect(phpunitTransformer.constructor.name).toBe('PHPUnitTransformer');
+    });
+});

--- a/src/PHPUnit/TestParser/Transformers/TransformerFactory.ts
+++ b/src/PHPUnit/TestParser/Transformers/TransformerFactory.ts
@@ -1,13 +1,56 @@
 import { PestTransformer } from './PestTransformer';
 import { PHPUnitTransformer } from './PHPUnitTransformer';
+import { AppState } from '../../../AppState';
+
+interface TransformerInput {
+    classFQN?: string;
+    locationHint?: string;
+    testResultName?: string;
+}
 
 export abstract class TransformerFactory {
-    static isPest(text: string) {
-        return /^pest|^P\\|pest_qn:\/\//i.test(text);
+    static getTextFromInput(input: TransformerInput | string): string {
+        if (typeof input === 'string') {
+            return input;
+        }
+
+        return input.classFQN || input.locationHint || '';
     }
 
-    static factory(text: string) {
-        return this.isPest(text) ? new PestTransformer() : new PHPUnitTransformer();
+    static isPest(input: TransformerInput | string) {
+        const text = this.getTextFromInput(input);
+
+        if (/^pest|^P\\|pest_qn:\/\//i.test(text)) {
+            return true;
+        }
+
+        if (/php_qn:\/\//i.test(text)) {
+            return false;
+        }
+
+        if (text.startsWith('file://')) {
+            return this.checkByParserId(input);
+        }
+
+        return false;
+    }
+
+    static checkByParserId(input: TransformerInput | string): boolean {
+        if (typeof input === 'string' || typeof input.locationHint === 'undefined') {
+            return false;
+        }
+
+        const parserId = input.locationHint
+            .split('://')[1]
+            .replace(/^tests\//i, 'Tests\\')
+            .replace(/\//g, '\\')
+            .replace(/\.php$/, '');
+
+        return AppState.getParserTestType(parserId) ?? false;
+    }
+
+    static factory(input: TransformerInput | string) {
+        return this.isPest(input) ? new PestTransformer() : new PHPUnitTransformer();
     }
 }
 


### PR DESCRIPTION
This PR fix an issue where locationHint starting with 'file://'
 was incorrectly identified as non-Pest test files. This was observed with:
- PHP 8.1.31
- Pest 2.36.0
- PHPUnit 10.5.36

##teamcity[testSuiteStarted name='/path/to/workspace/phpunit.xml'' locationHint='file://tests/Feature/ExampleTest.php' flowId='OOOO']

or

##teamcity[testSuiteStarted name='Test Suite' locationHint='file://tests/Feature/ExampleTest.php' flowId='OOOO']