### PR TITLE
Allow specifying debug launch configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This extension contributes the following settings:
 - `phpunit.clearOutputOnRun`: True will clear the output when we run a new test. False will leave the output after every
   test.
 - `phpunit.showAfterExecution` Specify if the test report will automatically be shown after execution
-
+- `phpunit.debuggerConfig` Specify the debugger launch configuration
 ## Commands
 
 The following commands are available in VS Code's command palette, use the ID to add them to your keyboard shortcuts:

--- a/package.json
+++ b/package.json
@@ -136,6 +136,11 @@
           "default": "onFailure",
           "description": "Specify if the test report will automatically be shown after execution",
           "scope": "application"
+        },
+        "phpunit.debuggerConfig": {
+          "type": "string",
+          "default": null,
+          "description": "The name of a launch configuration to use for debugging PHPUnit tests"
         }
       }
     }

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -28,7 +28,10 @@ export class Handler {
             command.setExtra(['-dxdebug.mode=debug', '-dxdebug.start_with_request=1']);
 
             const wsf = workspace.getWorkspaceFolder(this.testCollection.getWorkspace());
-            await debug.startDebugging(wsf, { type: 'php', request: 'launch', name: 'PHPUnit' });
+            const debuggerConfigName = this.configuration.get('debuggerConfig') as string | undefined;
+            const defaultDebuggerConfig = { type: 'php', request: 'launch', name: 'PHPUnit' };
+            const debuggerConfig = debuggerConfigName ?? defaultDebuggerConfig;
+            await debug.startDebugging(wsf, debuggerConfig);
             // TODO: perhaps wait for the debug session
         }
 


### PR DESCRIPTION
Running PHPUnit remotely requires setting up certain debugger configurations, such as pathMappings. Without these settings, the debugger may not function correctly.

This commit introduces a new configuration option, debuggerConfig, which allows specifying the launch configuration for debugging unit tests.