### PR TITLE
Replace the -f flag for --functional when running paratest

### DIFF
--- a/src/PHPUnit/CommandBuilder/CommandBuilder.test.ts
+++ b/src/PHPUnit/CommandBuilder/CommandBuilder.test.ts
@@ -11,7 +11,7 @@ describe('CommandBuilder Test', () => {
             });
         };
 
-        it('should add -f when PHPUnit binary is paratest and has --filter', () => {
+        it('should add --functional when PHPUnit binary is paratest and has --filter', () => {
             const builder = givenBuilder({
                 phpunit: 'vendor/bin/paratest',
             }).setArguments('--filter=\'^.*::(test_passed)( with data set .*)?$\'');
@@ -23,7 +23,7 @@ describe('CommandBuilder Test', () => {
                 '--filter=^.*::(test_passed)( with data set .*)?$',
                 '--colors=never',
                 '--teamcity',
-                '-f',
+                '--functional',
             ]);
         });
 
@@ -107,7 +107,7 @@ describe('CommandBuilder Test', () => {
             });
         };
 
-        it('should add -f when PHPUnit binary is paratest and has --filter', () => {
+        it('should add --functional when PHPUnit binary is paratest and has --filter', () => {
             const cwd = phpUnitProject('');
             const builder = givenCommandBuilder({
                 command: 'docker run -i --rm -v ${PWD}:/app -w /app phpunit-stub',
@@ -130,7 +130,7 @@ describe('CommandBuilder Test', () => {
                 '--filter=^.*::(test_passed)( with data set .*)?$',
                 '--colors=never',
                 '--teamcity',
-                '-f',
+                '--functional',
             ]);
         });
 
@@ -154,7 +154,7 @@ describe('CommandBuilder Test', () => {
                     `'--filter=^.*::(test_passed)( with data set .*)?$'`,
                     `'--colors=never'`,
                     `'--teamcity'`,
-                    `'-f'`,
+                    `'--functional'`,
                 ].join(' '),
             ]);
         });

--- a/src/PHPUnit/CommandBuilder/CommandBuilder.ts
+++ b/src/PHPUnit/CommandBuilder/CommandBuilder.ts
@@ -128,7 +128,7 @@ export class CommandBuilder {
     }
 
     private setParaTestFunctional(args: string[]) {
-        return this.isParaTestFunctional(args) ? [...args, '-f'] : args;
+        return this.isParaTestFunctional(args) ? [...args, '--functional'] : args;
     }
 
     private isParaTestFunctional(args: string[]) {


### PR DESCRIPTION
In paratest 7 the -f shorthand for --functional was removed. This patch now explicitly uses --functional so that paratest 7 will continue to work with the extension.

Look at the updated docs here: https://github.com/paratestphp/paratest