### PR TITLE
Fix coverage parsing for projects that use namespaces

### DIFF
--- a/src/CloverParser.test.ts
+++ b/src/CloverParser.test.ts
@@ -5,8 +5,8 @@ import { CloverParser } from './CloverParser';
 describe('CloverParser test', () => {
     it('parseClover', async () => {
         const cf = await CloverParser.parseClover('src/PHPUnit/__tests__/fixtures/test1.clover.xml');
-        expect(cf.length).toEqual(2);
-        const dc = cf[0].generateDetailedCoverage();
+        expect(cf.length).toEqual(3);
+        const dc = cf[1].generateDetailedCoverage();
         expect(dc.length).toEqual(6);
         expect(dc[0].executed).toEqual(2);
         if (dc[0].location instanceof Position) {

--- a/src/PHPUnit/Element.test.ts
+++ b/src/PHPUnit/Element.test.ts
@@ -1,32 +1,10 @@
 import { Element } from './Element';
 
-describe('Element', () => {
+describe('Element Test', () => {
     it('querySelectorAll should traverse arrays', () => {
-        const data = {
-            root: {
-                // 'list' is an array of objects
-                list: [
-                    { item: { '@_name': 'A' } },
-                    { item: { '@_name': 'B' } }
-                ]
-            }
-        };
-
-        const element = new Element(data);
-
-        // Selector 'root list item' requires traversing 'list' array to find 'item'
-        const results = element.querySelectorAll('root list item');
-
-        expect(results.length).toEqual(2);
-        expect(results[0].getAttribute('name')).toEqual('A');
-        expect(results[1].getAttribute('name')).toEqual('B');
-    });
-
-    it('querySelectorAll should handle objects mixed with arrays', () => {
         const data = {
             coverage: {
                 project: {
-                    // 'package' is an array here (multi-namespace case)
                     package: [
                         { file: { '@_name': 'file1.php' } },
                         { file: { '@_name': 'file2.php' } }
@@ -41,6 +19,37 @@ describe('Element', () => {
         expect(files.length).toEqual(2);
         expect(files[0].getAttribute('name')).toEqual('file1.php');
         expect(files[1].getAttribute('name')).toEqual('file2.php');
+    });
+
+    it('querySelectorAll should handle objects mixed with arrays', () => {
+        const data = {
+            coverage: {
+                project: [
+                    { file: { '@_name': 'file.php' } },
+                    {
+                        package: [
+                            { file: { '@_name': 'file1.php' } },
+                        ]
+                    },
+                    {
+                        package: [
+                            { file: { '@_name': 'file2.php' } }
+                        ]
+                    }
+                ]
+            }
+        };
+
+        const element = new Element(data);
+
+        const files1 = element.querySelectorAll('coverage project package file');
+        expect(files1.length).toEqual(2);
+        expect(files1[0].getAttribute('name')).toEqual('file1.php');
+        expect(files1[1].getAttribute('name')).toEqual('file2.php');
+
+        const files2 = element.querySelectorAll('coverage project file');
+        expect(files2.length).toEqual(1);
+        expect(files2[0].getAttribute('name')).toEqual('file.php');
     });
 
     it('getAttribute should retrieve values', () => {

--- a/src/PHPUnit/PHPUnitXML.test.ts
+++ b/src/PHPUnit/PHPUnitXML.test.ts
@@ -1,7 +1,6 @@
 import { join } from 'node:path';
 import { URI } from 'vscode-uri';
 import { generateXML, phpUnitProject } from './__tests__/utils';
-import { Element } from './Element';
 import { PHPUnitXML } from './PHPUnitXML';
 
 describe('PHPUnit XML Test', () => {
@@ -326,36 +325,6 @@ describe('PHPUnit XML Test', () => {
             { type: 'exclude', tag: 'directory', prefix: undefined, suffix: '.php', value: 'src/generated' },
             { type: 'exclude', tag: 'file', value: 'src/autoload.php' },
         ]);
-    });
-
-    it('coverage with multiple namespaces (intermediate array)', () => {
-        // XML where 'package' repeats, creating an array structure in the parser
-        const xml = generateXML(`
-            <coverage>
-                <project>
-                    <package name="NamespaceA">
-                        <file name="A.php"/>
-                    </package>
-                    <package name="NamespaceB">
-                        <file name="B.php"/>
-                    </package>
-                </project>
-            </coverage>
-        `);
-
-        // We need to access private method or verify via side effect if getCoverage isn't public.
-        // Assuming we can test Element traversal via the loaded instance:
-        const phpUnitXml = new PHPUnitXML();
-        phpUnitXml.load(xml, 'phpunit.xml');
-
-        // Access the underlying element to verify traversal logic in this context
-        // Note: strict property access might require casting or internal testing
-        const element = (phpUnitXml as any).element as Element; // Accessing private element for verification
-
-        const files = element.querySelectorAll('phpunit coverage project package file');
-        expect(files.length).toEqual(2);
-        expect(files[0].getAttribute('name')).toEqual('A.php');
-        expect(files[1].getAttribute('name')).toEqual('B.php');
     });
 
     it('load file', async () => {

--- a/src/PHPUnit/__tests__/fixtures/test1.clover.xml
+++ b/src/PHPUnit/__tests__/fixtures/test1.clover.xml
@@ -25,6 +25,9 @@
         <metrics loc="19" ncloc="19" classes="1" methods="2" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="4" coveredelements="4"/>
       </file>
     </package>
+    <file name="C:\local_disk\zobo\Projects\vscode-php-debug\vscode-phpunit\src\PHPUnit\__tests__\fixtures\phpunit-stub\src\Common.php">
+      <metrics loc="16" ncloc="3" classes="0" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
+    </file>
     <metrics files="2" loc="43" ncloc="43" classes="2" methods="5" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="5" coveredstatements="4" elements="10" coveredelements="8"/>
   </project>
 </coverage>


### PR DESCRIPTION
In projects with more than one namespace the coverage was not correctly parsed.

Having multiple namespaces resulted in the following hierarchy being output by the XMLParser:

```json
{
    "node": {
        "?xml": {
            "@_version": "1.0",
            "@_encoding": "UTF-8"
        },
        "coverage": {
            "project": {
                "package": [
                    {
                        "file": {
                            /* ... */
                        }
                    },
                    {
                        "file": [
                            {
                                /* ... */
                            }
                        ]
                    }
                ]
            }
        }
    }
}
```

This was not correctly handled by `querySelectorAll`, which assumed that only the innermost selected node could be an array.

This MR corrects that.