### PR TITLE
refactor: encapsulate ClassHierarchy as TestCollection internal detail

### DIFF
--- a/packages/extension/src/Observers/DatasetChildObserver.test.ts
+++ b/packages/extension/src/Observers/DatasetChildObserver.test.ts
@@ -1,6 +1,5 @@
 import {
     ChainAstParser,
-    ClassHierarchy,
     PHPUnitXML,
     PhpParserAstParser,
     type TeamcityEvent,
@@ -38,10 +37,9 @@ describe('DatasetChildObserver', () => {
             phpUnitProject('phpunit.xml'),
         );
 
-        const classHierarchy = new ClassHierarchy();
         const astParser = new ChainAstParser([new TreeSitterAstParser(), new PhpParserAstParser()]);
         const testParser = new TestParser(phpUnitXML, astParser);
-        testCollection = new TestCollection(ctrl, phpUnitXML, testParser, classHierarchy);
+        testCollection = new TestCollection(ctrl, phpUnitXML, testParser);
 
         await testCollection.add(URI.file(phpUnitProject('tests/AssertionsTest.php')));
 

--- a/packages/extension/src/TestCollection/TestCollection.test.ts
+++ b/packages/extension/src/TestCollection/TestCollection.test.ts
@@ -1,6 +1,5 @@
 import {
     ChainAstParser,
-    ClassHierarchy,
     createDatasetDefinition,
     PHPUnitXML,
     PhpParserAstParser,
@@ -78,11 +77,10 @@ describe('TestCollection', () => {
         const phpUnitXML = new PHPUnitXML();
         phpUnitXML.load(generateXML(text), configurationFile);
 
-        const classHierarchy = new ClassHierarchy();
         const astParser = new ChainAstParser([new TreeSitterAstParser(), new PhpParserAstParser()]);
         const testParser = new TestParser(phpUnitXML, astParser);
 
-        return new TestCollection(ctrl, phpUnitXML, testParser, classHierarchy);
+        return new TestCollection(ctrl, phpUnitXML, testParser);
     };
 
     const givenCodes = (codes: CODE[], configurationFile: string) => {

--- a/packages/extension/src/TestCollection/TestCollection.ts
+++ b/packages/extension/src/TestCollection/TestCollection.ts
@@ -1,7 +1,6 @@
 import {
     TestCollection as BaseTestCollection,
     type ChangeResult,
-    ClassHierarchy,
     type File,
     PHPUnitXML,
     type TestDefinition,
@@ -32,9 +31,8 @@ export class TestCollection {
         @inject(TYPES.TestController) private ctrl: TestController,
         @inject(PHPUnitXML) private phpUnitXML: PHPUnitXML,
         @inject(TestParser) testParser: TestParser,
-        @inject(ClassHierarchy) classHierarchy: ClassHierarchy,
     ) {
-        this.base = new BaseTestCollection(phpUnitXML, testParser, classHierarchy);
+        this.base = new BaseTestCollection(phpUnitXML, testParser);
     }
 
     get rootItems(): TestItemCollection {

--- a/packages/extension/src/TestExecution/TestQueueBuilder.test.ts
+++ b/packages/extension/src/TestExecution/TestQueueBuilder.test.ts
@@ -1,6 +1,5 @@
 import {
     ChainAstParser,
-    ClassHierarchy,
     PHPUnitXML,
     PhpParserAstParser,
     TestParser,
@@ -30,10 +29,9 @@ describe('TestQueueBuilder', () => {
                 </testsuites>`),
             phpUnitProject('phpunit.xml'),
         );
-        const classHierarchy = new ClassHierarchy();
         const astParser = new ChainAstParser([new TreeSitterAstParser(), new PhpParserAstParser()]);
         const testParser = new TestParser(phpUnitXML, astParser);
-        collection = new TestCollection(ctrl, phpUnitXML, testParser, classHierarchy);
+        collection = new TestCollection(ctrl, phpUnitXML, testParser);
         builder = new TestQueueBuilder(collection);
     });
 

--- a/packages/extension/src/container.ts
+++ b/packages/extension/src/container.ts
@@ -1,7 +1,6 @@
 import {
     BinaryDetector,
     ChainAstParser,
-    ClassHierarchy,
     PHPUnitXML,
     PhpParserAstParser,
     TestParser,
@@ -77,10 +76,6 @@ function createChildContainer(parent: Container, workspaceFolder: WorkspaceFolde
         )
         .inSingletonScope();
 
-    child
-        .bind(ClassHierarchy)
-        .toDynamicValue(() => new ClassHierarchy())
-        .inSingletonScope();
     child
         .bind(TestParser)
         .toDynamicValue((context) => {

--- a/packages/phpunit/src/TestCollection/TestCollection.test.ts
+++ b/packages/phpunit/src/TestCollection/TestCollection.test.ts
@@ -13,9 +13,8 @@ beforeAll(async () => initTreeSitter());
 describe('TestCollection', () => {
     const phpUnitXML = new PHPUnitXML();
     const astParser = new ChainAstParser([new TreeSitterAstParser(), new PhpParserAstParser()]);
-    const classHierarchy = new ClassHierarchy();
     const testParser = new TestParser(phpUnitXML, astParser);
-    const testCollection = new TestCollection(phpUnitXML, testParser, classHierarchy);
+    const testCollection = new TestCollection(phpUnitXML, testParser);
 
     const givenTestCollection = (text: string) => {
         phpUnitXML.load(generateXML(text), phpUnitProject('phpunit.xml'));
@@ -57,7 +56,7 @@ describe('TestCollection', () => {
         }
     };
 
-    it('should own classHierarchy and clear on reset', async () => {
+    it('should clear state on reset', async () => {
         const collection = givenTestCollection(`
             <testsuites>
                 <testsuite name="default">
@@ -65,14 +64,12 @@ describe('TestCollection', () => {
                 </testsuite>
             </testsuites>`);
 
-        await collection.change(URI.file(phpUnitProject('tests/AssertionsTest.php')));
+        const uri = URI.file(phpUnitProject('tests/AssertionsTest.php'));
+        await collection.change(uri);
+        expect(collection.has(uri)).toBe(true);
 
-        // ClassHierarchy should have entries after parsing
-        expect(classHierarchy.get('Tests\\AssertionsTest')).toBeDefined();
-
-        // reset should clear classHierarchy
         collection.reset();
-        expect(classHierarchy.get('Tests\\AssertionsTest')).toBeUndefined();
+        expect(collection.has(uri)).toBe(false);
     });
 
     it('classHierarchy should be owned by TestCollection, not TestParser', () => {

--- a/packages/phpunit/src/TestCollection/TestCollection.ts
+++ b/packages/phpunit/src/TestCollection/TestCollection.ts
@@ -2,7 +2,7 @@ import { extname, join } from 'node:path';
 import { Minimatch } from 'minimatch';
 import { URI } from 'vscode-uri';
 import type { PHPUnitXML, TestDefinition, TestParser, TestSuite } from '../index';
-import type { ClassHierarchy } from '../TestParser/ClassHierarchy';
+import { ClassHierarchy } from '../TestParser/ClassHierarchy';
 
 export interface File<T> {
     testsuite: string;
@@ -21,10 +21,11 @@ export class TestCollection {
     private fileIndex = new Map<string, string>();
     private parseQueue: Promise<void> = Promise.resolve();
 
+    private classHierarchy = new ClassHierarchy();
+
     constructor(
         private phpUnitXML: PHPUnitXML,
         private testParser: TestParser,
-        private classHierarchy: ClassHierarchy,
     ) {}
 
     get size() {

--- a/packages/phpunit/src/TestParser/index.ts
+++ b/packages/phpunit/src/TestParser/index.ts
@@ -4,6 +4,5 @@ export {
     PhpParserAstParser,
     TreeSitterAstParser,
 } from '../Interpreter/AstParser';
-export * from './ClassHierarchy';
 export { createDatasetDefinition, resolveDatasetDefinition } from './TestDefinitionBuilder';
 export * from './TestParser';


### PR DESCRIPTION
## Summary
- `ClassHierarchy` is now created internally by `TestCollection` instead of being injected via constructor
- Removed `ClassHierarchy` from public API exports (`TestParser/index.ts`)
- Removed `ClassHierarchy` DI binding from extension container
- Updated all test files to match new constructor signature
- Updated README (EN + zh-TW): merged "Parse test files" and "Track file changes" sections into a single `TestCollection`-centric example

## Test plan
- [x] `pnpm --filter phpunit test` — 879 tests pass
- [x] `pnpm --filter phpunit build` — clean
- [x] `pnpm --filter vscode-phpunit exec tsc --noEmit` — clean
- [x] `pnpm --filter vscode-phpunit test` — 355 tests pass