### PR TITLE
docs: fix marketplace badges showing shields.io retired-badge placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Monorepo for the **PHPUnit & Pest Test Explorer** VS Code extension.
 
-[![Version](https://img.shields.io/vscode-marketplace/v/recca0120.vscode-phpunit.svg?style=flat-square&label=vscode%20marketplace)](https://marketplace.visualstudio.com/items?itemName=recca0120.vscode-phpunit)
-[![Installs](https://img.shields.io/vscode-marketplace/i/recca0120.vscode-phpunit.svg?style=flat-square)](https://marketplace.visualstudio.com/items?itemName=recca0120.vscode-phpunit)
+[![Version](https://vsmarketplacebadges.dev/version/recca0120.vscode-phpunit.svg)](https://marketplace.visualstudio.com/items?itemName=recca0120.vscode-phpunit)
+[![Installs](https://vsmarketplacebadges.dev/installs/recca0120.vscode-phpunit.svg)](https://marketplace.visualstudio.com/items?itemName=recca0120.vscode-phpunit)
 [![License](https://img.shields.io/github/license/recca0120/vscode-phpunit.svg?style=flat-square)](LICENSE.md)
 
 ## Packages

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -2,8 +2,8 @@
 
 **PHPUnit & Pest Test Explorer** VS Code 擴充套件的 Monorepo。
 
-[![Version](https://img.shields.io/vscode-marketplace/v/recca0120.vscode-phpunit.svg?style=flat-square&label=vscode%20marketplace)](https://marketplace.visualstudio.com/items?itemName=recca0120.vscode-phpunit)
-[![Installs](https://img.shields.io/vscode-marketplace/i/recca0120.vscode-phpunit.svg?style=flat-square)](https://marketplace.visualstudio.com/items?itemName=recca0120.vscode-phpunit)
+[![Version](https://vsmarketplacebadges.dev/version/recca0120.vscode-phpunit.svg)](https://marketplace.visualstudio.com/items?itemName=recca0120.vscode-phpunit)
+[![Installs](https://vsmarketplacebadges.dev/installs/recca0120.vscode-phpunit.svg)](https://marketplace.visualstudio.com/items?itemName=recca0120.vscode-phpunit)
 [![License](https://img.shields.io/github/license/recca0120/vscode-phpunit.svg?style=flat-square)](LICENSE.md)
 
 ## 套件


### PR DESCRIPTION
## Summary
- shields.io retired the `vscode-marketplace` badge category, so the Version/Installs badges in both READMEs rendered as a generic "retired badge" placeholder instead of real data.
- Switched both badges to `vsmarketplacebadges.dev`, the community-maintained replacement commonly used by other VS Code extensions after the shields.io deprecation.

## Test plan
- [x] Verified both new badge URLs render real data (version `v3.9.38`, install count) instead of the retired placeholder