### PR TITLE
fix: use short --user-data-dir to avoid macOS AF_UNIX socket path limit in e2e

### DIFF
--- a/packages/extension/.vscode-test.mjs
+++ b/packages/extension/.vscode-test.mjs
@@ -11,9 +11,10 @@ const mochaOpts = { ui: 'tdd', timeout: 30_000 };
 // packages/extension/.vscode-test/user-data) can exceed that on CI runners
 // and crash VS Code with "listen EINVAL". Force a short, fixed path instead.
 // os.tmpdir() itself is too long on macOS (a per-process /var/folders/...
-// path), so prefer the short, stable /tmp there.
+// path), so prefer RUNNER_TEMP (short and job-scoped on GitHub Actions) or,
+// failing that, the short, stable /tmp.
 function userDataDirArgs(label) {
-    const base = platform() === 'darwin' ? '/tmp' : tmpdir();
+    const base = platform() === 'darwin' ? (process.env.RUNNER_TEMP ?? '/tmp') : tmpdir();
 
     return ['--user-data-dir', join(base, 'vsc-e2e', label)];
 }

--- a/packages/extension/.vscode-test.mjs
+++ b/packages/extension/.vscode-test.mjs
@@ -1,9 +1,22 @@
 import { execSync } from 'node:child_process';
+import { platform, tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { defineConfig } from '@vscode/test-cli';
 
 const fixturesPath = resolve(import.meta.dirname, '../phpunit/tests/fixtures');
 const mochaOpts = { ui: 'tdd', timeout: 30_000 };
+
+// macOS caps AF_UNIX socket paths at 104 bytes; the default user-data-dir
+// (nested under the checkout path, e.g. .../vscode-phpunit/vscode-phpunit/
+// packages/extension/.vscode-test/user-data) can exceed that on CI runners
+// and crash VS Code with "listen EINVAL". Force a short, fixed path instead.
+// os.tmpdir() itself is too long on macOS (a per-process /var/folders/...
+// path), so prefer the short, stable /tmp there.
+function userDataDirArgs(label) {
+    const base = platform() === 'darwin' ? '/tmp' : tmpdir();
+
+    return ['--user-data-dir', join(base, 'vsc-e2e', label)];
+}
 
 function detectPhpUnitStubs() {
     const versions = [9, 10, 11, 12];
@@ -66,7 +79,11 @@ if (phpUnitStubs.length > 0) {
         label: `phpunit:${stub.name}`,
         files: 'out/tests/suite/**/*.test.js',
         mocha: mochaOpts,
-        launchArgs: [...stub.launchArgs, '--disable-extensions'],
+        launchArgs: [
+            ...stub.launchArgs,
+            '--disable-extensions',
+            ...userDataDirArgs(`phpunit-${stub.name}`),
+        ],
         env: {
             STUB_TYPE: stub.type,
             STUB_VERSION: stub.name,
@@ -83,7 +100,11 @@ if (pestStubs.length > 0) {
         label: `pest:${stub.name}`,
         files: 'out/tests/suite/**/*.test.js',
         mocha: mochaOpts,
-        launchArgs: [...stub.launchArgs, '--disable-extensions'],
+        launchArgs: [
+            ...stub.launchArgs,
+            '--disable-extensions',
+            ...userDataDirArgs(`pest-${stub.name}`),
+        ],
         env: {
             STUB_TYPE: stub.type,
             STUB_VERSION: stub.name,
@@ -103,7 +124,11 @@ if (phpUnitStubs.length > 0 && pestStubs.length > 0) {
         label: 'multi-workspace',
         files: 'out/tests/suite-multi/**/*.test.js',
         mocha: mochaOpts,
-        launchArgs: [workspacePath, '--disable-extensions'],
+        launchArgs: [
+            workspacePath,
+            '--disable-extensions',
+            ...userDataDirArgs('multi-workspace'),
+        ],
         env: {
             PHPUNIT_STUB_VERSION: phpUnit.name,
             PHPUNIT_STUB_BINARY: phpUnit.binary,
@@ -126,7 +151,7 @@ try {
         label: 'issue-381',
         files: 'out/tests/suite-issue-381/**/*.test.js',
         mocha: mochaOpts,
-        launchArgs: [workspacePath, '--disable-extensions'],
+        launchArgs: [workspacePath, '--disable-extensions', ...userDataDirArgs('issue-381')],
         env: {
             ISSUE381_PHPUNIT_BINARY: issue381Binary,
         },


### PR DESCRIPTION
## Summary
- e2e (macos-latest) was failing on unrelated PRs with `listen EINVAL: invalid argument .../.vscode-test/user-data/1.12-main.sock`.
- macOS caps Unix domain socket paths at 104 bytes. The default `--user-data-dir` nests under the checkout path (`.../vscode-phpunit/vscode-phpunit/packages/extension/.vscode-test/user-data` on GitHub Actions), which is long enough that VS Code's own IPC socket file exceeds the limit and crashes on launch.
- Force a short, fixed `--user-data-dir` per test config. `os.tmpdir()` itself is too long on macOS (a per-process `/var/folders/.../T/` path leaves too little headroom), so use `/tmp` there specifically; other platforms keep `os.tmpdir()`.

## Test plan
- [x] Confirmed locally on macOS: VS Code launches successfully with `--user-data-dir /tmp/vsc-e2e/<label>` (verified via `ps aux` — process alive, no EINVAL crash)
- [ ] Waiting on CI (macos-latest e2e job specifically) to confirm the fix in the actual runner environment