### PR TITLE
docs: fix marketplace badges in the extension's own README

### DIFF
--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -1,7 +1,7 @@
 # PHPUnit & Pest Test Explorer for VS Code
 
-[![Version](https://img.shields.io/vscode-marketplace/v/recca0120.vscode-phpunit.svg?style=flat-square&label=vscode%20marketplace)](https://marketplace.visualstudio.com/items?itemName=recca0120.vscode-phpunit)
-[![Installs](https://img.shields.io/vscode-marketplace/i/recca0120.vscode-phpunit.svg?style=flat-square)](https://marketplace.visualstudio.com/items?itemName=recca0120.vscode-phpunit)
+[![Version](https://vsmarketplacebadges.dev/version/recca0120.vscode-phpunit.svg)](https://marketplace.visualstudio.com/items?itemName=recca0120.vscode-phpunit)
+[![Installs](https://vsmarketplacebadges.dev/installs/recca0120.vscode-phpunit.svg)](https://marketplace.visualstudio.com/items?itemName=recca0120.vscode-phpunit)
 [![License](https://img.shields.io/github/license/recca0120/vscode-phpunit.svg?style=flat-square)](LICENSE.md)
 
 [繁體中文](https://github.com/recca0120/vscode-phpunit/blob/main/packages/extension/README.zh-TW.md)

--- a/packages/extension/README.zh-TW.md
+++ b/packages/extension/README.zh-TW.md
@@ -1,7 +1,7 @@
 # PHPUnit & Pest Test Explorer for VS Code
 
-[![Version](https://img.shields.io/vscode-marketplace/v/recca0120.vscode-phpunit.svg?style=flat-square&label=vscode%20marketplace)](https://marketplace.visualstudio.com/items?itemName=recca0120.vscode-phpunit)
-[![Installs](https://img.shields.io/vscode-marketplace/i/recca0120.vscode-phpunit.svg?style=flat-square)](https://marketplace.visualstudio.com/items?itemName=recca0120.vscode-phpunit)
+[![Version](https://vsmarketplacebadges.dev/version/recca0120.vscode-phpunit.svg)](https://marketplace.visualstudio.com/items?itemName=recca0120.vscode-phpunit)
+[![Installs](https://vsmarketplacebadges.dev/installs/recca0120.vscode-phpunit.svg)](https://marketplace.visualstudio.com/items?itemName=recca0120.vscode-phpunit)
 [![License](https://img.shields.io/github/license/recca0120/vscode-phpunit.svg?style=flat-square)](LICENSE.md)
 
 [English](https://github.com/recca0120/vscode-phpunit/blob/main/packages/extension/README.md)


### PR DESCRIPTION
## Summary
Follow-up to #422 — that PR only fixed the root READMEs. `packages/extension/README.md` (and its zh-TW variant), which is the README actually published to the VS Code Marketplace listing, still used the retired shields.io `vscode-marketplace` badge category. Switched both to `vsmarketplacebadges.dev` to match.

Note: `img/icon.png` at the repo root is intentionally kept as-is — it's not a leftover duplicate, it's required by pestphp.com's editor-setup docs page, which hardcodes `https://raw.githubusercontent.com/recca0120/vscode-phpunit/main/img/icon.png`. Removing/moving it would break that external page's rendered logo.