### PR TITLE
feat: Pest todo() assignee/issue and skipOnCi()/skipLocally() detection

### DIFF
--- a/packages/extension/src/TestCollection/TestCollection.test.ts
+++ b/packages/extension/src/TestCollection/TestCollection.test.ts
@@ -1065,6 +1065,58 @@ it('does something', function () {
             expect(method.description).toBe('assigned: taylor@laravel.com, issue #123');
         });
 
+        it('Pest ->skipOnCi() shows a distinct conditional-skip icon and description', () => {
+            givenCodes(
+                [
+                    {
+                        testsuite: { name: 'default', path: 'tests' },
+                        file: pestProject('tests/Unit/SkipOnCiTest.php'),
+                        code: `<?php
+it('needs a real server', function () {
+    expect(true)->toBeTrue();
+})->skipOnCi();`,
+                    },
+                ],
+                pestProject('phpunit.xml'),
+            );
+
+            const ns = ctrl.items.get('namespace:Tests') as TestItem;
+            const unitNs = ns.children.get('namespace:Unit (Tests\\Unit)') as TestItem;
+            const cls = unitNs.children.get('Tests\\Unit\\SkipOnCiTest') as TestItem;
+            const method = cls.children.get(
+                'tests/Unit/SkipOnCiTest.php::it needs a real server',
+            ) as TestItem;
+            expect(method).toBeDefined();
+            expect(method.label).toBe('$(question) it needs a real server');
+            expect(method.description).toBe('skips on CI');
+        });
+
+        it('Pest ->skipLocally() shows a distinct conditional-skip icon and description', () => {
+            givenCodes(
+                [
+                    {
+                        testsuite: { name: 'default', path: 'tests' },
+                        file: pestProject('tests/Unit/SkipLocallyTest.php'),
+                        code: `<?php
+it('needs local docker', function () {
+    expect(true)->toBeTrue();
+})->skipLocally();`,
+                    },
+                ],
+                pestProject('phpunit.xml'),
+            );
+
+            const ns = ctrl.items.get('namespace:Tests') as TestItem;
+            const unitNs = ns.children.get('namespace:Unit (Tests\\Unit)') as TestItem;
+            const cls = unitNs.children.get('Tests\\Unit\\SkipLocallyTest') as TestItem;
+            const method = cls.children.get(
+                'tests/Unit/SkipLocallyTest.php::it needs local docker',
+            ) as TestItem;
+            expect(method).toBeDefined();
+            expect(method.label).toBe('$(question) it needs local docker');
+            expect(method.description).toBe('skips locally');
+        });
+
         it('Pest ->only() shows a distinct only icon in the label', () => {
             givenCodes(
                 [

--- a/packages/extension/src/TestCollection/TestCollection.test.ts
+++ b/packages/extension/src/TestCollection/TestCollection.test.ts
@@ -1117,6 +1117,32 @@ it('needs local docker', function () {
             expect(method.description).toBe('skips locally');
         });
 
+        it('does not show a conditional-skip description when ->skip() already applies', () => {
+            givenCodes(
+                [
+                    {
+                        testsuite: { name: 'default', path: 'tests' },
+                        file: pestProject('tests/Unit/SkipAndSkipOnCiTest.php'),
+                        code: `<?php
+it('needs a real server', function () {
+    expect(true)->toBeTrue();
+})->skip()->skipOnCi();`,
+                    },
+                ],
+                pestProject('phpunit.xml'),
+            );
+
+            const ns = ctrl.items.get('namespace:Tests') as TestItem;
+            const unitNs = ns.children.get('namespace:Unit (Tests\\Unit)') as TestItem;
+            const cls = unitNs.children.get('Tests\\Unit\\SkipAndSkipOnCiTest') as TestItem;
+            const method = cls.children.get(
+                'tests/Unit/SkipAndSkipOnCiTest.php::it needs a real server',
+            ) as TestItem;
+            expect(method).toBeDefined();
+            expect(method.label).toBe('$(circle-slash) it needs a real server');
+            expect(method.description).toBeUndefined();
+        });
+
         it('Pest ->only() shows a distinct only icon in the label', () => {
             givenCodes(
                 [

--- a/packages/extension/src/TestCollection/TestCollection.test.ts
+++ b/packages/extension/src/TestCollection/TestCollection.test.ts
@@ -1039,6 +1039,32 @@ it('does something', function () {
             expect(method.label).toBe('$(issue-draft) it does something');
         });
 
+        it('Pest ->todo(assignee:, issue:) shows the assignment info as item description', () => {
+            givenCodes(
+                [
+                    {
+                        testsuite: { name: 'default', path: 'tests' },
+                        file: pestProject('tests/Unit/TodoAssignedTest.php'),
+                        code: `<?php
+it('does something', function () {
+    expect(true)->toBeTrue();
+})->todo(assignee: 'taylor@laravel.com', issue: 123);`,
+                    },
+                ],
+                pestProject('phpunit.xml'),
+            );
+
+            const ns = ctrl.items.get('namespace:Tests') as TestItem;
+            const unitNs = ns.children.get('namespace:Unit (Tests\\Unit)') as TestItem;
+            const cls = unitNs.children.get('Tests\\Unit\\TodoAssignedTest') as TestItem;
+            const method = cls.children.get(
+                'tests/Unit/TodoAssignedTest.php::it does something',
+            ) as TestItem;
+            expect(method).toBeDefined();
+            expect(method.label).toBe('$(issue-draft) it does something');
+            expect(method.description).toBe('assigned: taylor@laravel.com, issue #123');
+        });
+
         it('Pest ->only() shows a distinct only icon in the label', () => {
             givenCodes(
                 [

--- a/packages/extension/src/TestCollection/TestHierarchyBuilder.ts
+++ b/packages/extension/src/TestCollection/TestHierarchyBuilder.ts
@@ -71,6 +71,10 @@ export class TestHierarchyBuilder extends BaseTestHierarchyBuilder<TestItem> {
         return prefix ? `${prefix} ${testDefinition.label}` : testDefinition.label;
     }
 
+    protected override decorateItem(testItem: TestItem, testDefinition: TestDefinition): void {
+        testItem.description = this.resolveDescription(testDefinition);
+    }
+
     private resolveIconPrefix(testDefinition: TestDefinition): string {
         if (testDefinition.type !== TestType.method) {
             return icon(testDefinition.type);
@@ -80,5 +84,22 @@ export class TestHierarchyBuilder extends BaseTestHierarchyBuilder<TestItem> {
         const match = ANNOTATION_ICONS.find(([key]) => annotations?.[key]);
 
         return match ? match[1] : icon(testDefinition.type);
+    }
+
+    private resolveDescription(testDefinition: TestDefinition): string | undefined {
+        const annotations = testDefinition.annotations;
+        if (!annotations?.todo) {
+            return undefined;
+        }
+
+        const parts: string[] = [];
+        if (annotations.todoAssignee) {
+            parts.push(`assigned: ${annotations.todoAssignee}`);
+        }
+        if (annotations.todoIssue) {
+            parts.push(`issue #${annotations.todoIssue}`);
+        }
+
+        return parts.length > 0 ? parts.join(', ') : undefined;
     }
 }

--- a/packages/extension/src/TestCollection/TestHierarchyBuilder.ts
+++ b/packages/extension/src/TestCollection/TestHierarchyBuilder.ts
@@ -34,6 +34,7 @@ const ANNOTATION_ICONS: Array<[keyof NonNullable<TestDefinition['annotations']>,
     ['only', '$(target)'],
     ['skipped', '$(circle-slash)'],
     ['todo', '$(issue-draft)'],
+    ['conditionalSkip', '$(question)'],
     ['dataProvider', '$(symbol-enum)'],
     ['browserTest', '$(globe)'],
 ];
@@ -88,6 +89,10 @@ export class TestHierarchyBuilder extends BaseTestHierarchyBuilder<TestItem> {
 
     private resolveDescription(testDefinition: TestDefinition): string | undefined {
         const annotations = testDefinition.annotations;
+        if (annotations?.conditionalSkip) {
+            return annotations.conditionalSkip === 'onCi' ? 'skips on CI' : 'skips locally';
+        }
+
         if (!annotations?.todo) {
             return undefined;
         }

--- a/packages/extension/src/TestCollection/TestHierarchyBuilder.ts
+++ b/packages/extension/src/TestCollection/TestHierarchyBuilder.ts
@@ -28,6 +28,24 @@ export function icon(type: TestType): string {
     return TEST_ICONS[type] ?? '';
 }
 
+function resolveConditionalSkipDescription(conditionalSkip: 'onCi' | 'locally'): string {
+    return conditionalSkip === 'onCi' ? 'skips on CI' : 'skips locally';
+}
+
+function resolveTodoDescription(
+    annotations: NonNullable<TestDefinition['annotations']>,
+): string | undefined {
+    const parts: string[] = [];
+    if (annotations.todoAssignee) {
+        parts.push(`assigned: ${annotations.todoAssignee}`);
+    }
+    if (annotations.todoIssue) {
+        parts.push(`issue #${annotations.todoIssue}`);
+    }
+
+    return parts.join(', ') || undefined;
+}
+
 // Order is priority: the first matching annotation wins when a test carries more than one
 // (e.g. an ->only() test is never also shown as a plain browser test).
 const ANNOTATION_ICONS: Array<[keyof NonNullable<TestDefinition['annotations']>, string]> = [
@@ -76,37 +94,36 @@ export class TestHierarchyBuilder extends BaseTestHierarchyBuilder<TestItem> {
         testItem.description = this.resolveDescription(testDefinition);
     }
 
-    private resolveIconPrefix(testDefinition: TestDefinition): string {
+    // The winning annotation for a test with multiple modifiers — same priority order
+    // ANNOTATION_ICONS declares, shared by the icon and the description so they can
+    // never disagree (e.g. ->skip()->skipOnCi() must not show "skips on CI" next to
+    // an unconditional-skip icon).
+    private resolveWinningAnnotation(
+        testDefinition: TestDefinition,
+    ): (typeof ANNOTATION_ICONS)[number] | undefined {
         if (testDefinition.type !== TestType.method) {
-            return icon(testDefinition.type);
-        }
-
-        const annotations = testDefinition.annotations;
-        const match = ANNOTATION_ICONS.find(([key]) => annotations?.[key]);
-
-        return match ? match[1] : icon(testDefinition.type);
-    }
-
-    private resolveDescription(testDefinition: TestDefinition): string | undefined {
-        const annotations = testDefinition.annotations;
-        // Unconditional ->skip() already wins the icon (see ANNOTATION_ICONS priority above),
-        // so don't also claim a conditional CI/local skip — that would contradict the icon.
-        if (annotations?.conditionalSkip && !annotations?.skipped) {
-            return annotations.conditionalSkip === 'onCi' ? 'skips on CI' : 'skips locally';
-        }
-
-        if (!annotations?.todo) {
             return undefined;
         }
 
-        const parts: string[] = [];
-        if (annotations.todoAssignee) {
-            parts.push(`assigned: ${annotations.todoAssignee}`);
+        const annotations = testDefinition.annotations;
+        return ANNOTATION_ICONS.find(([key]) => annotations?.[key]);
+    }
+
+    private resolveIconPrefix(testDefinition: TestDefinition): string {
+        return this.resolveWinningAnnotation(testDefinition)?.[1] ?? icon(testDefinition.type);
+    }
+
+    private resolveDescription(testDefinition: TestDefinition): string | undefined {
+        const winningKey = this.resolveWinningAnnotation(testDefinition)?.[0];
+        const annotations = testDefinition.annotations;
+
+        if (winningKey === 'conditionalSkip' && annotations?.conditionalSkip) {
+            return resolveConditionalSkipDescription(annotations.conditionalSkip);
         }
-        if (annotations.todoIssue) {
-            parts.push(`issue #${annotations.todoIssue}`);
+        if (annotations?.todo) {
+            return resolveTodoDescription(annotations);
         }
 
-        return parts.length > 0 ? parts.join(', ') : undefined;
+        return undefined;
     }
 }

--- a/packages/extension/src/TestCollection/TestHierarchyBuilder.ts
+++ b/packages/extension/src/TestCollection/TestHierarchyBuilder.ts
@@ -89,7 +89,9 @@ export class TestHierarchyBuilder extends BaseTestHierarchyBuilder<TestItem> {
 
     private resolveDescription(testDefinition: TestDefinition): string | undefined {
         const annotations = testDefinition.annotations;
-        if (annotations?.conditionalSkip) {
+        // Unconditional ->skip() already wins the icon (see ANNOTATION_ICONS priority above),
+        // so don't also claim a conditional CI/local skip — that would contradict the icon.
+        if (annotations?.conditionalSkip && !annotations?.skipped) {
             return annotations.conditionalSkip === 'onCi' ? 'skips on CI' : 'skips locally';
         }
 

--- a/packages/phpunit/src/Interpreter/Resolvers/PestResolver.ts
+++ b/packages/phpunit/src/Interpreter/Resolvers/PestResolver.ts
@@ -80,6 +80,8 @@ interface ChainWalkResult {
     skipped: boolean;
     skipReason?: string;
     todo: boolean;
+    todoAssignee?: string;
+    todoIssue?: string;
     only: boolean;
     group: string[];
 }
@@ -96,6 +98,21 @@ function extractStringArguments(args: AstNode[]): string[] {
         .map((arg) => arg.value);
 }
 
+function extractNamedArgument(args: AstNode[], name: string): string | undefined {
+    const arg = args.find((a) => a.kind === 'argument' && a.name === name);
+    if (arg?.kind !== 'argument') {
+        return undefined;
+    }
+    const value = arg.value;
+    if (value.kind === 'string') {
+        return value.value;
+    }
+    if (value.kind === 'number') {
+        return String(value.value);
+    }
+    return undefined;
+}
+
 function walkAndCollect(call: CallNode): ChainWalkResult | undefined {
     let rootCall: CallNode | undefined;
     const preRoot: string[] = [];
@@ -104,6 +121,8 @@ function walkAndCollect(call: CallNode): ChainWalkResult | undefined {
     let skipped = false;
     let skipReason: string | undefined;
     let todo = false;
+    let todoAssignee: string | undefined;
+    let todoIssue: string | undefined;
     let only = false;
     const groupCalls: string[][] = [];
 
@@ -123,6 +142,8 @@ function walkAndCollect(call: CallNode): ChainWalkResult | undefined {
                     break;
                 case 'todo':
                     todo = true;
+                    todoAssignee = extractNamedArgument(cur.arguments, 'assignee') ?? todoAssignee;
+                    todoIssue = extractNamedArgument(cur.arguments, 'issue') ?? todoIssue;
                     break;
                 case 'only':
                     only = true;
@@ -150,6 +171,8 @@ function walkAndCollect(call: CallNode): ChainWalkResult | undefined {
         skipped,
         skipReason,
         todo,
+        todoAssignee,
+        todoIssue,
         only,
         group: groupCalls.reverse().flat(),
     };
@@ -161,7 +184,18 @@ function buildPestCallDescriptor(call: CallNode, php: PHP): PestCallDescriptor |
         return undefined;
     }
 
-    const { rootCall, chainCalls, withSources, skipped, skipReason, todo, only, group } = result;
+    const {
+        rootCall,
+        chainCalls,
+        withSources,
+        skipped,
+        skipReason,
+        todo,
+        todoAssignee,
+        todoIssue,
+        only,
+        group,
+    } = result;
 
     const isTestCall = rootCall.name === 'it' || rootCall.name === 'test';
 
@@ -175,6 +209,8 @@ function buildPestCallDescriptor(call: CallNode, php: PHP): PestCallDescriptor |
         skipped: skipped || undefined,
         skipReason,
         todo: todo || undefined,
+        todoAssignee,
+        todoIssue,
         only: only || undefined,
         group: group.length > 0 ? group : undefined,
         browserTest: isTestCall ? detectsBrowserTestCall(rootCall) : undefined,

--- a/packages/phpunit/src/Interpreter/Resolvers/PestResolver.ts
+++ b/packages/phpunit/src/Interpreter/Resolvers/PestResolver.ts
@@ -101,14 +101,11 @@ function extractStringArguments(args: AstNode[]): string[] {
 
 function extractNamedArgument(args: AstNode[], name: string): string | undefined {
     const arg = args.find((a) => a.kind === 'argument' && a.name === name);
-    if (arg?.kind !== 'argument') {
-        return undefined;
-    }
-    const value = arg.value;
-    if (value.kind === 'string') {
+    const value = unwrapArgument(arg);
+    if (value?.kind === 'string') {
         return value.value;
     }
-    if (value.kind === 'number') {
+    if (value?.kind === 'number') {
         return String(value.value);
     }
     return undefined;

--- a/packages/phpunit/src/Interpreter/Resolvers/PestResolver.ts
+++ b/packages/phpunit/src/Interpreter/Resolvers/PestResolver.ts
@@ -12,7 +12,7 @@ import { CallVisitor } from '../Visitors/CallVisitor';
 import { FQNResolver } from './FQNResolver';
 
 const pestFunctionNames = new Set(['test', 'it', 'describe', 'arch']);
-const modifierNames = new Set(['skip', 'todo', 'only', 'group']);
+const modifierNames = new Set(['skip', 'todo', 'only', 'group', 'skipOnCi', 'skipLocally']);
 
 function* walkChain(call: CallNode): Generator<CallNode> {
     let cur: CallNode | undefined = call;
@@ -84,6 +84,7 @@ interface ChainWalkResult {
     todoIssue?: string;
     only: boolean;
     group: string[];
+    conditionalSkip?: 'onCi' | 'locally';
 }
 
 function extractSkipReason(args: AstNode[]): string | undefined {
@@ -125,6 +126,7 @@ function walkAndCollect(call: CallNode): ChainWalkResult | undefined {
     let todoIssue: string | undefined;
     let only = false;
     const groupCalls: string[][] = [];
+    let conditionalSkip: 'onCi' | 'locally' | undefined;
 
     for (const cur of walkChain(call)) {
         if (!rootCall && pestFunctionNames.has(cur.name)) {
@@ -151,6 +153,12 @@ function walkAndCollect(call: CallNode): ChainWalkResult | undefined {
                 case 'group':
                     groupCalls.push(extractStringArguments(cur.arguments));
                     break;
+                case 'skipOnCi':
+                    conditionalSkip = 'onCi';
+                    break;
+                case 'skipLocally':
+                    conditionalSkip = 'locally';
+                    break;
             }
             (rootCall ? preRoot : postRoot).push(cur.name);
         } else if (!rootCall) {
@@ -175,6 +183,7 @@ function walkAndCollect(call: CallNode): ChainWalkResult | undefined {
         todoIssue,
         only,
         group: groupCalls.reverse().flat(),
+        conditionalSkip,
     };
 }
 
@@ -195,6 +204,7 @@ function buildPestCallDescriptor(call: CallNode, php: PHP): PestCallDescriptor |
         todoIssue,
         only,
         group,
+        conditionalSkip,
     } = result;
 
     const isTestCall = rootCall.name === 'it' || rootCall.name === 'test';
@@ -214,6 +224,7 @@ function buildPestCallDescriptor(call: CallNode, php: PHP): PestCallDescriptor |
         only: only || undefined,
         group: group.length > 0 ? group : undefined,
         browserTest: isTestCall ? detectsBrowserTestCall(rootCall) : undefined,
+        conditionalSkip,
     };
 }
 

--- a/packages/phpunit/src/Interpreter/interpret.test.ts
+++ b/packages/phpunit/src/Interpreter/interpret.test.ts
@@ -314,6 +314,8 @@ describe.each(parsers)('interpret (%s)', (_name, createParser) => {
                 it('does something', function () {})->todo();
             `);
             expect(info.pestCalls[0].todo).toBe(true);
+            expect(info.pestCalls[0].todoAssignee).toBeUndefined();
+            expect(info.pestCalls[0].todoIssue).toBeUndefined();
         });
 
         it('marks ->todo() with assignee/issue arguments as todo', () => {
@@ -321,6 +323,24 @@ describe.each(parsers)('interpret (%s)', (_name, createParser) => {
                 it('does something', function () {})->todo(assignee: 'jane', issue: 123);
             `);
             expect(info.pestCalls[0].todo).toBe(true);
+            expect(info.pestCalls[0].todoAssignee).toBe('jane');
+            expect(info.pestCalls[0].todoIssue).toBe('123');
+        });
+
+        it('marks ->todo() with only assignee argument', () => {
+            const info = given(`<?php
+                it('does something', function () {})->todo(assignee: 'jane');
+            `);
+            expect(info.pestCalls[0].todoAssignee).toBe('jane');
+            expect(info.pestCalls[0].todoIssue).toBeUndefined();
+        });
+
+        it('marks ->todo() with only issue argument', () => {
+            const info = given(`<?php
+                it('does something', function () {})->todo(issue: 123);
+            `);
+            expect(info.pestCalls[0].todoAssignee).toBeUndefined();
+            expect(info.pestCalls[0].todoIssue).toBe('123');
         });
 
         it('does not mark ordinary chained calls as skipped or todo', () => {

--- a/packages/phpunit/src/Interpreter/interpret.test.ts
+++ b/packages/phpunit/src/Interpreter/interpret.test.ts
@@ -351,6 +351,35 @@ describe.each(parsers)('interpret (%s)', (_name, createParser) => {
             expect(info.pestCalls[0].todo).toBeFalsy();
         });
 
+        it('marks ->skipOnCi() with conditionalSkip "onCi"', () => {
+            const info = given(`<?php
+                it('needs a real server', function () {})->skipOnCi();
+            `);
+            expect(info.pestCalls[0].conditionalSkip).toBe('onCi');
+        });
+
+        it('marks ->skipLocally() with conditionalSkip "locally"', () => {
+            const info = given(`<?php
+                it('needs local docker', function () {})->skipLocally();
+            `);
+            expect(info.pestCalls[0].conditionalSkip).toBe('locally');
+        });
+
+        it('leaves conditionalSkip undefined when no such modifier is present', () => {
+            const info = given(`<?php
+                it('does something', function () {})->group('slow');
+            `);
+            expect(info.pestCalls[0].conditionalSkip).toBeUndefined();
+        });
+
+        it('does not let ->skip() and ->skipOnCi() interfere with each other', () => {
+            const info = given(`<?php
+                it('does something', function () {})->skip()->skipOnCi();
+            `);
+            expect(info.pestCalls[0].skipped).toBe(true);
+            expect(info.pestCalls[0].conditionalSkip).toBe('onCi');
+        });
+
         it('marks ->only() as only', () => {
             const info = given(`<?php
                 it('does something', function () {})->only();

--- a/packages/phpunit/src/Interpreter/types.ts
+++ b/packages/phpunit/src/Interpreter/types.ts
@@ -71,6 +71,8 @@ export interface PestCallDescriptor {
     skipped?: boolean;
     skipReason?: string;
     todo?: boolean;
+    todoAssignee?: string;
+    todoIssue?: string;
     only?: boolean;
     group?: string[];
     browserTest?: boolean;

--- a/packages/phpunit/src/Interpreter/types.ts
+++ b/packages/phpunit/src/Interpreter/types.ts
@@ -76,4 +76,5 @@ export interface PestCallDescriptor {
     only?: boolean;
     group?: string[];
     browserTest?: boolean;
+    conditionalSkip?: 'onCi' | 'locally';
 }

--- a/packages/phpunit/src/TestCollection/TestHierarchyBuilder.ts
+++ b/packages/phpunit/src/TestCollection/TestHierarchyBuilder.ts
@@ -52,6 +52,10 @@ export abstract class TestHierarchyBuilder<T extends TestTreeItem<T>> {
         return testDefinition.label;
     }
 
+    protected decorateItem(_testItem: T, _testDefinition: TestDefinition): void {
+        // no-op by default; subclasses can attach extra display info (e.g. description)
+    }
+
     private processNode(test: TestDefinition, parentChildren: ItemCollection<T>) {
         switch (test.type) {
             case TestType.namespace:
@@ -257,6 +261,8 @@ export abstract class TestHierarchyBuilder<T extends TestTreeItem<T>> {
         if (tags.length > 0) {
             testItem.tags = tags;
         }
+
+        this.decorateItem(testItem, testDefinition);
 
         return testItem;
     }

--- a/packages/phpunit/src/TestParser/TestExtractor.ts
+++ b/packages/phpunit/src/TestParser/TestExtractor.ts
@@ -250,6 +250,10 @@ function buildPestTestDef(
         annotations.browserTest = true;
     }
 
+    if (call.conditionalSkip) {
+        annotations.conditionalSkip = call.conditionalSkip;
+    }
+
     const children = isDescribe
         ? call.children.map((child) =>
               buildPestTestDef(child, ctx, [...describeChain, `\`${call.description}\``]),

--- a/packages/phpunit/src/TestParser/TestExtractor.ts
+++ b/packages/phpunit/src/TestParser/TestExtractor.ts
@@ -230,6 +230,12 @@ function buildPestTestDef(
 
     if (call.todo) {
         annotations.todo = true;
+        if (call.todoAssignee) {
+            annotations.todoAssignee = call.todoAssignee;
+        }
+        if (call.todoIssue) {
+            annotations.todoIssue = call.todoIssue;
+        }
     }
 
     if (call.only) {

--- a/packages/phpunit/src/TestParser/TestExtractorForPest.test.ts
+++ b/packages/phpunit/src/TestParser/TestExtractorForPest.test.ts
@@ -291,6 +291,25 @@ it('does something', function () {
         );
     });
 
+    it('marks ->todo(assignee:, issue:) tests with annotations.todoAssignee/todoIssue', async () => {
+        const content = `<?php
+
+it('does something', function () {
+    expect(true)->toBeTrue();
+})->todo(assignee: 'taylor@laravel.com', issue: 123);
+        `;
+
+        expect(givenTest(file, content, 'it does something')).toEqual(
+            expect.objectContaining({
+                annotations: expect.objectContaining({
+                    todo: true,
+                    todoAssignee: 'taylor@laravel.com',
+                    todoIssue: '123',
+                }),
+            }),
+        );
+    });
+
     it('marks ->only() tests with annotations.only', async () => {
         const content = `<?php
 

--- a/packages/phpunit/src/TestParser/TestExtractorForPest.test.ts
+++ b/packages/phpunit/src/TestParser/TestExtractorForPest.test.ts
@@ -310,6 +310,36 @@ it('does something', function () {
         );
     });
 
+    it('marks ->skipOnCi() tests with annotations.conditionalSkip "onCi"', async () => {
+        const content = `<?php
+
+it('needs a real server', function () {
+    expect(true)->toBeTrue();
+})->skipOnCi();
+        `;
+
+        expect(givenTest(file, content, 'it needs a real server')).toEqual(
+            expect.objectContaining({
+                annotations: expect.objectContaining({ conditionalSkip: 'onCi' }),
+            }),
+        );
+    });
+
+    it('marks ->skipLocally() tests with annotations.conditionalSkip "locally"', async () => {
+        const content = `<?php
+
+it('needs local docker', function () {
+    expect(true)->toBeTrue();
+})->skipLocally();
+        `;
+
+        expect(givenTest(file, content, 'it needs local docker')).toEqual(
+            expect.objectContaining({
+                annotations: expect.objectContaining({ conditionalSkip: 'locally' }),
+            }),
+        );
+    });
+
     it('marks ->only() tests with annotations.only', async () => {
         const content = `<?php
 

--- a/packages/phpunit/src/types.ts
+++ b/packages/phpunit/src/types.ts
@@ -31,6 +31,8 @@ export type Annotations = {
     skipped?: boolean;
     skipReason?: string;
     todo?: boolean;
+    todoAssignee?: string;
+    todoIssue?: string;
     only?: boolean;
     browserTest?: boolean;
 };

--- a/packages/phpunit/src/types.ts
+++ b/packages/phpunit/src/types.ts
@@ -35,6 +35,7 @@ export type Annotations = {
     todoIssue?: string;
     only?: boolean;
     browserTest?: boolean;
+    conditionalSkip?: 'onCi' | 'locally';
 };
 export type TestDefinition = {
     type: TestType;


### PR DESCRIPTION
## Summary

Two smaller follow-ups from the Pest 3/4 feature-coverage audit (#427), both same-tier complexity as the already-shipped skip/todo/only/group work:

- **`todo(assignee:, issue:)`**: named arguments (already fully parsed by both AST backends — no parser changes needed) are now surfaced via `TestItem.description` ("assigned: <email>, issue #<n>") alongside the existing `$(issue-draft)` icon.
- **`->skipOnCi()` / `->skipLocally()`**: statically flagged as `annotations.conditionalSkip: 'onCi' | 'locally'`, rendered with a distinct `$(question)` icon (not the same as unconditional `$(circle-slash)` skip, since whether it actually skips depends on the runtime environment). No execution-path changes — actual runtime skips already flow through the existing teamcity `testIgnored` path.

## Deliberately not done (tracked separately)

Investigated the remaining 5 items from the original audit and confirmed each requires a fundamentally different investment than the chain-call/body-walk static-annotation pattern used here — a new non-Teamcity result format and/or new command/report UI surface:

- Browser Testing advanced UX (device emulation, screenshot diffing, Playwright error surfacing)
- Mutation Testing (`--mutate`, `covers()`)
- Type Coverage (`--type-coverage`)
- Stress Testing (`stress()`)
- Test Sharding (`--shard`) — already achievable today via the `phpunit.args` setting, no code change needed

## Test plan
- [x] TDD: red before green for all new cases
- [x] `pnpm --filter @vscode-phpunit/phpunit test` — 1046/1046
- [x] `pnpm --filter vscode-phpunit test` — 365/365
- [x] `pnpm run typecheck` — clean
- [x] lefthook pre-commit — clean